### PR TITLE
Registry Accessibility Fixes (Batch 1)

### DIFF
--- a/docs/sample_pages/AlertDetail.html
+++ b/docs/sample_pages/AlertDetail.html
@@ -26,7 +26,10 @@
 </div>
 
 <div class="column column-80">
-  <input type="text" placeholder="Search for objects, files, work items...">
+  <label>
+    "Search for objects, files, work items..."
+    <input type="text">
+  </label>
   <i class="fa fa-search"></i>
 </div>
 

--- a/docs/sample_pages/Dashboard.html
+++ b/docs/sample_pages/Dashboard.html
@@ -26,7 +26,10 @@
 </div>
 
 <div class="column column-80">
-  <input type="text" placeholder="Search for objects, files, work items...">
+  <label>
+    Search for objects, files, work items...
+    <input type="text">  
+  </label>
   <i class="fa fa-search"></i>
 </div>
 

--- a/docs/sample_pages/ObjectDetail.html
+++ b/docs/sample_pages/ObjectDetail.html
@@ -26,7 +26,10 @@
 </div>
 
 <div class="column column-80">
-  <input type="text" placeholder="Search for objects, files, work items...">
+  <label>
+    "Search for objects, files, work items..."
+    <input type="text">
+  </label>
   <i class="fa fa-search"></i>
 </div>
 
@@ -420,7 +423,10 @@
 
   <div class="row">
     <div class="column column-70">
-      <input type="text" placeholder="Filter by partial identifier or exact checksum" id="fileFilter">
+      <label>
+        Filter by partial identifier or exact checksum
+        <input type="text" id="fileFilter">
+      </label>
     </div>
     <div class="column column-30">
       <input type="button" value="Filter" onclick="filterFiles('A')">

--- a/docs/sample_pages/UserList.html
+++ b/docs/sample_pages/UserList.html
@@ -26,7 +26,10 @@
 </div>
 
 <div class="column column-80">
-  <input type="text" placeholder="Search for objects, files, work items...">
+  <label>
+    Search for objects, files, work items...
+    <input type="text">
+  </label>
   <i class="fa fa-search"></i>
 </div>
 
@@ -115,7 +118,7 @@
       
 
 <label>Name Contains
-<input type="text" name="name__contains" placeholder="Name Contains">
+<input type="text" name="name__contains">
 </label>
 
 
@@ -126,7 +129,7 @@
       
 
 <label>Email Contains
-<input type="text" name="email__contains" placeholder="Email Contains">
+<input type="text" name="email__contains">
 </label>
 
 

--- a/docs/sample_pages/UserNew.html
+++ b/docs/sample_pages/UserNew.html
@@ -26,7 +26,10 @@
 </div>
 
 <div class="column column-80">
-  <input type="text" placeholder="Search for objects, files, work items...">
+  <label>
+    Search for objects, files, work items...
+    <input type="text">
+  </label>
   <i class="fa fa-search"></i>
 </div>
 
@@ -105,7 +108,7 @@
   
 
 <label>Name
-<input type="text" name="Name" placeholder="Name" required="" oninvalid="this.setCustomValidity('Name must contain at least 2 characters.')" oninput="this.setCustomValidity('')">
+<input type="text" name="Name" required="" oninvalid="this.setCustomValidity('Name must contain at least 2 characters.')" oninput="this.setCustomValidity('')">
 </label>
 
 
@@ -115,7 +118,7 @@
   
 
 <label>Email Address
-  <input type="email" name="Email" placeholder="Email Address" required="" oninvalid="this.setCustomValidity('Email address is required.')" oninput="this.setCustomValidity('')">
+  <input type="email" name="Email" required="" oninvalid="this.setCustomValidity('Email address is required.')" oninput="this.setCustomValidity('')">
 </label>
 
 
@@ -124,8 +127,8 @@
 
   
 
-<label>Phone
-  <input type="tel" name="PhoneNumber" placeholder="Phone in format 212-555-1212" oninvalid="this.setCustomValidity('Please enter a phone number in format \u002b2125551212.')" oninput="this.setCustomValidity('')">
+<label>Phone in format 212-555-1212
+  <input type="tel" name="PhoneNumber" oninvalid="this.setCustomValidity('Please enter a phone number in format \u002b2125551212.')" oninput="this.setCustomValidity('')">
 </label>
 
 
@@ -153,8 +156,8 @@
 
   
 
-<label>Must enable two-factor auth by
-<input type="date" name="GracePeriod" placeholder="mm/dd/yyyy" max="2099-12-31" min="2021-01-01" oninvalid="this.setCustomValidity('Enter a date specifying when this user must enable two-factor authentication.')" oninput="this.setCustomValidity('')">
+<label>Must enable two-factor auth by (mm/dd/yyyy)
+<input type="date" name="GracePeriod" max="2099-12-31" min="2021-01-01" oninvalid="this.setCustomValidity('Enter a date specifying when this user must enable two-factor authentication.')" oninput="this.setCustomValidity('')">
 </label>
 
 

--- a/docs/sample_pages/WorkItems.html
+++ b/docs/sample_pages/WorkItems.html
@@ -28,7 +28,10 @@
     </div>
 
     <div class="column column-80">
-      <input type="text" placeholder="Search for objects, files, work items...">
+      <label>
+        Search for objects, files, work items...
+        <input type="text">
+      </label>
       <i class="fa fa-search"></i>
     </div>
 
@@ -214,7 +217,7 @@
 
 
             <label>Name of tar file
-              <input type="text" name="name" placeholder="Name of tar file">
+              <input type="text" name="name">
             </label>
 
 
@@ -225,7 +228,7 @@
 
 
             <label>ETag (from S3 upload)
-              <input type="text" name="etag" placeholder="ETag">
+              <input type="text" name="etag">
             </label>
 
 
@@ -267,7 +270,7 @@
 
 
             <label>Processed On or After
-              <input type="date" name="date_processed__gteq" placeholder="Processed On or After">
+              <input type="date" name="date_processed__gteq">
             </label>
 
 
@@ -278,7 +281,7 @@
 
 
             <label>Processed On or Before
-              <input type="date" name="date_processed__lteq" placeholder="Processed On or Before">
+              <input type="date" name="date_processed__lteq">
             </label>
 
 
@@ -312,7 +315,7 @@
 
 
             <label>Object Identifier
-              <input type="text" name="object_identifier" placeholder="Object Identifier">
+              <input type="text" name="object_identifier">
             </label>
 
 
@@ -323,7 +326,7 @@
 
 
             <label>File Identifier
-              <input type="text" name="generic_file_identifier" placeholder="File Identifier">
+              <input type="text" name="generic_file_identifier">
             </label>
 
 
@@ -373,7 +376,7 @@
 
 
             <label>Alternate Identifier
-              <input type="text" name="alt_identifier" placeholder="Alternate Identifier">
+              <input type="text" name="alt_identifier">
             </label>
 
 
@@ -384,7 +387,7 @@
 
 
             <label>Bag Group Identifier
-              <input type="text" name="bag_group_identifier" placeholder="Bag Group Identifier">
+              <input type="text" name="bag_group_identifier">
             </label>
 
 
@@ -395,7 +398,7 @@
 
 
             <label>Bucket
-              <input type="text" name="bucket" placeholder="Bucket">
+              <input type="text" name="bucket">
             </label>
 
 
@@ -408,8 +411,8 @@
           <div class="column col-30">
 
 
-            <label>Initiated By
-              <input type="text" name="user" placeholder="User email address">
+            <label>Initiated By (User email address)
+              <input type="text" name="user">
             </label>
 
 
@@ -446,7 +449,7 @@
 
 
             <label>Min Size
-              <input type="number" name="size__gteq" placeholder="Min Size">
+              <input type="number" name="size__gteq">
             </label>
 
 
@@ -457,7 +460,7 @@
 
 
             <label>Max Size
-              <input type="number" name="size__lteq" placeholder="Max Size">
+              <input type="number" name="size__lteq">
             </label>
 
 

--- a/forms/alert_filter_form.go
+++ b/forms/alert_filter_form.go
@@ -40,32 +40,27 @@ func NewAlertFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmodels.User
 
 func (f *AlertFilterForm) init() {
 	f.Fields["created_at__gteq"] = &Field{
-		Name:        "created_at__gteq",
-		Label:       "Created On or After",
-		Placeholder: "Created On or After",
+		Name:  "created_at__gteq",
+		Label: "Created On or After",
 	}
 	f.Fields["created_at__lteq"] = &Field{
-		Name:        "created_at__lteq",
-		Label:       "Created On or Before",
-		Placeholder: "Created On or Before",
+		Name:  "created_at__lteq",
+		Label: "Created On or Before",
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["type"] = &Field{
-		Name:        "type",
-		Label:       "Alert Type",
-		Placeholder: "Alert Type",
-		Options:     Options(constants.AlertTypes),
+		Name:    "type",
+		Label:   "Alert Type",
+		Options: Options(constants.AlertTypes),
 	}
 	f.Fields["user_id"] = &Field{
-		Name:        "user_id",
-		Label:       "Recipient",
-		Placeholder: "Recipient",
-		Options:     f.userOptions,
+		Name:    "user_id",
+		Label:   "Recipient",
+		Options: f.userOptions,
 	}
 }
 

--- a/forms/billing_report_filter_form.go
+++ b/forms/billing_report_filter_form.go
@@ -35,32 +35,28 @@ func NewBillingReportFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmod
 
 func (f *BillingReportFilterForm) init() {
 	f.Fields["start_date"] = &Field{
-		Name:        "start_date",
-		Label:       "Deposits from date",
-		Placeholder: "Deposits from",
-		Options:     ListDepositReportDates(false),
-		Attrs:       make(map[string]string),
+		Name:    "start_date",
+		Label:   "Deposits from date",
+		Options: ListDepositReportDates(false),
+		Attrs:   make(map[string]string),
 	}
 	f.Fields["end_date"] = &Field{
-		Name:        "end_date",
-		Label:       "Deposits up to date",
-		Placeholder: "Deposits up to",
-		Options:     ListDepositReportDates(false),
-		Attrs:       make(map[string]string),
+		Name:    "end_date",
+		Label:   "Deposits up to date",
+		Options: ListDepositReportDates(false),
+		Attrs:   make(map[string]string),
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
-		Attrs:       make(map[string]string),
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
+		Attrs:   make(map[string]string),
 	}
 	f.Fields["storage_option"] = &Field{
-		Name:        "storage_option",
-		Label:       "Storage Option",
-		Placeholder: "Storage Option",
-		Options:     Options(constants.StorageOptions),
-		Attrs:       make(map[string]string),
+		Name:    "storage_option",
+		Label:   "Storage Option",
+		Options: Options(constants.StorageOptions),
+		Attrs:   make(map[string]string),
 	}
 }
 

--- a/forms/deletion_request_filter_form.go
+++ b/forms/deletion_request_filter_form.go
@@ -34,32 +34,27 @@ func NewDeletionRequestFilterForm(fc *pgmodels.FilterCollection, actingUser *pgm
 
 func (f *DeletionRequestFilterForm) init() {
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["requested_at__lteq"] = &Field{
-		Name:        "requested_at__lteq",
-		Label:       "Requested On or Before",
-		Placeholder: "Requested On or Before",
+		Name:  "requested_at__lteq",
+		Label: "Requested On or Before",
 	}
 	f.Fields["requested_at__gteq"] = &Field{
-		Name:        "requested_at__gteq",
-		Label:       "Requested On or After",
-		Placeholder: "Requested On or After",
+		Name:  "requested_at__gteq",
+		Label: "Requested On or After",
 	}
 	f.Fields["stage"] = &Field{
-		Name:        "stage",
-		Label:       "Work Item Stage",
-		Placeholder: "Work Item Stage",
-		Options:     Options(constants.Stages),
+		Name:    "stage",
+		Label:   "Work Item Stage",
+		Options: Options(constants.Stages),
 	}
 	f.Fields["status"] = &Field{
-		Name:        "status",
-		Label:       "Work Item Status",
-		Placeholder: "Work Item Status",
-		Options:     Options(constants.Statuses),
+		Name:    "status",
+		Label:   "Work Item Status",
+		Options: Options(constants.Statuses),
 	}
 }
 

--- a/forms/deposit_report_filter_form.go
+++ b/forms/deposit_report_filter_form.go
@@ -35,47 +35,41 @@ func NewDepositReportFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmod
 
 func (f *DepositReportFilterForm) init() {
 	f.Fields["start_date"] = &Field{
-		Name:        "start_date",
-		Label:       "Deposits from",
-		Placeholder: "Deposits from",
-		Options:     ListDepositReportDates(false),
-		Attrs:       make(map[string]string),
+		Name:    "start_date",
+		Label:   "Deposits from",
+		Options: ListDepositReportDates(false),
+		Attrs:   make(map[string]string),
 	}
 	f.Fields["end_date"] = &Field{
-		Name:        "end_date",
-		Label:       "Deposits up to",
-		Placeholder: "Deposits up to",
-		Options:     ListDepositReportDates(true),
-		Attrs:       make(map[string]string),
+		Name:    "end_date",
+		Label:   "Deposits up to",
+		Options: ListDepositReportDates(true),
+		Attrs:   make(map[string]string),
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
-		Attrs:       make(map[string]string),
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
+		Attrs:   make(map[string]string),
 	}
 
 	storageOpts := Options(constants.StorageOptions)
 	storageOpts = append(storageOpts, &ListOption{Value: "Total", Text: "Total"})
 	f.Fields["storage_option"] = &Field{
-		Name:        "storage_option",
-		Label:       "Storage Option",
-		Placeholder: "Storage Option",
-		Options:     storageOpts,
-		Attrs:       make(map[string]string),
+		Name:    "storage_option",
+		Label:   "Storage Option",
+		Options: storageOpts,
+		Attrs:   make(map[string]string),
 	}
 	f.Fields["chart_metric"] = &Field{
-		Name:        "chart_metric",
-		Label:       "Chart Metric",
-		Placeholder: "Chart Metric",
-		Options:     DepositChartMetrics,
-		Attrs:       make(map[string]string),
+		Name:    "chart_metric",
+		Label:   "Chart Metric",
+		Options: DepositChartMetrics,
+		Attrs:   make(map[string]string),
 	}
 	f.Fields["report_type"] = &Field{
-		Name:        "report_type",
-		Label:       "Report Type",
-		Placeholder: "Report Type",
+		Name:  "report_type",
+		Label: "Report Type",
 		Options: []*ListOption{
 			{"by_inst", "Deposits by Institution", false},
 			{"over_time", "Deposits Over Time", false},

--- a/forms/file_filter_form.go
+++ b/forms/file_filter_form.go
@@ -33,57 +33,47 @@ func NewFileFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmodels.User)
 
 func (f *FileFilterForm) init() {
 	f.Fields["created_at__lteq"] = &Field{
-		Name:        "created_at__lteq",
-		Label:       "Created On or Before",
-		Placeholder: "Created On or Before",
+		Name:  "created_at__lteq",
+		Label: "Created On or Before",
 	}
 	f.Fields["created_at__gteq"] = &Field{
-		Name:        "created_at__gteq",
-		Label:       "Created On or After",
-		Placeholder: "Created On or After",
+		Name:  "created_at__gteq",
+		Label: "Created On or After",
 	}
 	f.Fields["identifier"] = &Field{
-		Name:        "identifier",
-		Label:       "File Identifier",
-		Placeholder: "File Identifier",
+		Name:  "identifier",
+		Label: "File Identifier",
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["state"] = &Field{
-		Name:        "state",
-		Label:       "State",
-		Placeholder: "State",
-		Options:     ObjectStateList,
+		Name:    "state",
+		Label:   "State",
+		Options: ObjectStateList,
 	}
 	f.Fields["size__gteq"] = &Field{
-		Name:        "size__gteq",
-		Label:       "Min Size",
-		Placeholder: "Min Size",
+		Name:  "size__gteq",
+		Label: "Min Size",
 	}
 	f.Fields["size__lteq"] = &Field{
-		Name:        "size__lteq",
-		Label:       "Max Size",
-		Placeholder: "Max Size",
+		Name:  "size__lteq",
+		Label: "Max Size",
 	}
 	f.Fields["storage_option"] = &Field{
-		Name:        "storage_option",
-		Label:       "Storage Option",
-		Placeholder: "Storage Option",
-		Options:     StorageOptionList,
+		Name:    "storage_option",
+		Label:   "Storage Option",
+		Options: StorageOptionList,
 	}
 	f.Fields["updated_at__lteq"] = &Field{
-		Name:        "updated_at__lteq",
-		Label:       "Updated On or Before",
-		Placeholder: "Updated On or Before",
+		Name:  "updated_at__lteq",
+		Label: "Updated On or Before",
 	}
 	f.Fields["updated_at__gteq"] = &Field{
-		Name:        "updated_at__gteq",
-		Label:       "Updated On or After",
-		Placeholder: "Updated On or After",
+		Name:  "updated_at__gteq",
+		Label: "Updated On or After",
 	}
 }
 

--- a/forms/institution_filter_form.go
+++ b/forms/institution_filter_form.go
@@ -34,15 +34,13 @@ func NewInstitutionFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmodel
 
 func (f *InstitutionFilterForm) init() {
 	f.Fields["name__contains"] = &Field{
-		Name:        "name__contains",
-		Label:       "Name Contains",
-		Placeholder: "Name Contains",
+		Name:  "name__contains",
+		Label: "Name Contains",
 	}
 	f.Fields["type"] = &Field{
-		Name:        "type",
-		Label:       "Type",
-		Placeholder: "Type",
-		Options:     InstTypeList,
+		Name:    "type",
+		Label:   "Type",
+		Options: InstTypeList,
 	}
 }
 

--- a/forms/institution_form.go
+++ b/forms/institution_form.go
@@ -27,10 +27,9 @@ func NewInstitutionForm(institution *pgmodels.Institution) (*InstitutionForm, er
 
 func (f *InstitutionForm) init() {
 	f.Fields["Name"] = &Field{
-		Name:        "Name",
-		Label:       "Name",
-		Placeholder: "Name",
-		ErrMsg:      pgmodels.ErrInstName,
+		Name:   "Name",
+		Label:  "Name",
+		ErrMsg: pgmodels.ErrInstName,
 		Attrs: map[string]string{
 			"required": "",
 			"min":      "2",
@@ -39,32 +38,29 @@ func (f *InstitutionForm) init() {
 	// The regex here matches the DNSName regex in
 	// github.com/asaskevich/govalidator/patterns.go
 	f.Fields["Identifier"] = &Field{
-		Name:        "Identifier",
-		Label:       "Identifier",
-		Placeholder: "Identifier",
-		ErrMsg:      pgmodels.ErrInstIdentifier,
+		Name:   "Identifier",
+		Label:  "Identifier",
+		ErrMsg: pgmodels.ErrInstIdentifier,
 		Attrs: map[string]string{
 			"required": "",
 			"pattern":  `^([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*[\._]?$`,
 		},
 	}
 	f.Fields["Type"] = &Field{
-		Name:        "Type",
-		Label:       "Institution Type",
-		Placeholder: "Institution Type",
-		ErrMsg:      pgmodels.ErrInstType,
-		Options:     InstTypeList,
+		Name:    "Type",
+		Label:   "Institution Type",
+		ErrMsg:  pgmodels.ErrInstType,
+		Options: InstTypeList,
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["MemberInstitutionID"] = &Field{
-		Name:        "MemberInstitutionID",
-		Label:       "Parent Institution",
-		Placeholder: "Parent Institution",
-		ErrMsg:      pgmodels.ErrInstMemberID,
-		Options:     f.instOptions,
-		Attrs:       map[string]string{},
+		Name:    "MemberInstitutionID",
+		Label:   "Parent Institution",
+		ErrMsg:  pgmodels.ErrInstMemberID,
+		Options: f.instOptions,
+		Attrs:   map[string]string{},
 	}
 	f.Fields["OTPEnabled"] = &Field{
 		Name:        "OTPEnabled",
@@ -86,18 +82,16 @@ func (f *InstitutionForm) init() {
 		},
 	}
 	f.Fields["ReceivingBucket"] = &Field{
-		Name:        "Receiving Bucket",
-		Label:       "Receiving Bucket",
-		Placeholder: "Receiving Bucket",
+		Name:  "Receiving Bucket",
+		Label: "Receiving Bucket",
 		Attrs: map[string]string{
 			"disabled": "",
 			"readonly": "",
 		},
 	}
 	f.Fields["RestoreBucket"] = &Field{
-		Name:        "Restoration Bucket",
-		Label:       "Restoration Bucket",
-		Placeholder: "Restoration Bucket",
+		Name:  "Restoration Bucket",
+		Label: "Restoration Bucket",
 		Attrs: map[string]string{
 			"disabled": "",
 			"readonly": "",

--- a/forms/object_filter_form.go
+++ b/forms/object_filter_form.go
@@ -40,19 +40,16 @@ func (f *ObjectFilterForm) init() {
 		Options:     Options(constants.AccessSettings),
 	}
 	f.Fields["alt_identifier__starts_with"] = &Field{
-		Name:        "alt_identifier__starts_with",
-		Label:       "Alternate Identifier (Prefix or Exact)",
-		Placeholder: "Alternate Identifier",
+		Name:  "alt_identifier__starts_with",
+		Label: "Alternate Identifier (Prefix or Exact)",
 	}
 	f.Fields["bag_group_identifier__starts_with"] = &Field{
-		Name:        "bag_group_identifier__starts_with",
-		Label:       "Bag Group Identifier (Prefix or Exact)",
-		Placeholder: "Bag Group Identifier",
+		Name:  "bag_group_identifier__starts_with",
+		Label: "Bag Group Identifier (Prefix or Exact)",
 	}
 	f.Fields["bag_name"] = &Field{
-		Name:        "bag_name",
-		Label:       "Bag Name",
-		Placeholder: "Bag Name",
+		Name:  "bag_name",
+		Label: "Bag Name",
 	}
 	f.Fields["bagit_profile_identifier"] = &Field{
 		Name:        "bagit_profile_identifier",
@@ -76,14 +73,12 @@ func (f *ObjectFilterForm) init() {
 		Placeholder: "ETag",
 	}
 	f.Fields["file_count__gteq"] = &Field{
-		Name:        "file_count__gteq",
-		Label:       "Min File Count",
-		Placeholder: "Min File Count",
+		Name:  "file_count__gteq",
+		Label: "Minimum File Count",
 	}
 	f.Fields["file_count__lteq"] = &Field{
-		Name:        "file_count__lteq",
-		Label:       "Max File Count",
-		Placeholder: "Max File Count",
+		Name:  "file_count__lteq",
+		Label: "Maximum File Count",
 	}
 	f.Fields["identifier"] = &Field{
 		Name:        "identifier",
@@ -91,9 +86,8 @@ func (f *ObjectFilterForm) init() {
 		Placeholder: "Object Identifier",
 	}
 	f.Fields["identifier__starts_with"] = &Field{
-		Name:        "identifier__starts_with",
-		Label:       "Object Identifier (Prefix or Exact)",
-		Placeholder: "Object Identifier (Prefix or Exact)",
+		Name:  "identifier__starts_with",
+		Label: "Object Identifier (Prefix or Exact)",
 	}
 	f.Fields["institution_id"] = &Field{
 		Name:        "institution_id",
@@ -108,19 +102,16 @@ func (f *ObjectFilterForm) init() {
 		Options:     f.instOptions,
 	}
 	f.Fields["internal_sender_identifier"] = &Field{
-		Name:        "internal_sender_identifier",
-		Label:       "Internal Sender Identifier",
-		Placeholder: "Internal Sender Identifier",
+		Name:  "internal_sender_identifier",
+		Label: "Internal Sender Identifier",
 	}
 	f.Fields["size__gteq"] = &Field{
-		Name:        "size__gteq",
-		Label:       "Min Size",
-		Placeholder: "Min Size",
+		Name:  "size__gteq",
+		Label: "Minimum Size",
 	}
 	f.Fields["size__lteq"] = &Field{
-		Name:        "size__lteq",
-		Label:       "Max Size",
-		Placeholder: "Max Size",
+		Name:  "size__lteq",
+		Label: "Maximum Size",
 	}
 	f.Fields["source_organization"] = &Field{
 		Name:        "source_organization",

--- a/forms/object_filter_form.go
+++ b/forms/object_filter_form.go
@@ -34,10 +34,9 @@ func NewObjectFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmodels.Use
 
 func (f *ObjectFilterForm) init() {
 	f.Fields["access"] = &Field{
-		Name:        "access",
-		Label:       "Access",
-		Placeholder: "Access",
-		Options:     Options(constants.AccessSettings),
+		Name:    "access",
+		Label:   "Access",
+		Options: Options(constants.AccessSettings),
 	}
 	f.Fields["alt_identifier__starts_with"] = &Field{
 		Name:  "alt_identifier__starts_with",
@@ -52,25 +51,21 @@ func (f *ObjectFilterForm) init() {
 		Label: "Bag Name",
 	}
 	f.Fields["bagit_profile_identifier"] = &Field{
-		Name:        "bagit_profile_identifier",
-		Label:       "BagIt Profile",
-		Placeholder: "BagIt Profile",
-		Options:     BagItProfileIdentifiers,
+		Name:    "bagit_profile_identifier",
+		Label:   "BagIt Profile",
+		Options: BagItProfileIdentifiers,
 	}
 	f.Fields["created_at__lteq"] = &Field{
-		Name:        "created_at__lteq",
-		Label:       "Created On or Before",
-		Placeholder: "Created On or Before",
+		Name:  "created_at__lteq",
+		Label: "Created On or Before",
 	}
 	f.Fields["created_at__gteq"] = &Field{
-		Name:        "created_at__gteq",
-		Label:       "Created On or After",
-		Placeholder: "Created On or After",
+		Name:  "created_at__gteq",
+		Label: "Created On or After",
 	}
 	f.Fields["etag"] = &Field{
-		Name:        "etag",
-		Label:       "ETag",
-		Placeholder: "ETag",
+		Name:  "etag",
+		Label: "ETag",
 	}
 	f.Fields["file_count__gteq"] = &Field{
 		Name:  "file_count__gteq",
@@ -81,25 +76,22 @@ func (f *ObjectFilterForm) init() {
 		Label: "Maximum File Count",
 	}
 	f.Fields["identifier"] = &Field{
-		Name:        "identifier",
-		Label:       "Object Identifier",
-		Placeholder: "Object Identifier",
+		Name:  "identifier",
+		Label: "Object Identifier",
 	}
 	f.Fields["identifier__starts_with"] = &Field{
 		Name:  "identifier__starts_with",
 		Label: "Object Identifier (Prefix or Exact)",
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["institution_parent_id"] = &Field{
-		Name:        "institution_parent_id",
-		Label:       "Parent Institution",
-		Placeholder: "Parent Institution",
-		Options:     f.instOptions,
+		Name:    "institution_parent_id",
+		Label:   "Parent Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["internal_sender_identifier"] = &Field{
 		Name:  "internal_sender_identifier",
@@ -114,31 +106,26 @@ func (f *ObjectFilterForm) init() {
 		Label: "Maximum Size",
 	}
 	f.Fields["source_organization"] = &Field{
-		Name:        "source_organization",
-		Label:       "Source Organization",
-		Placeholder: "Source Organization",
+		Name:  "source_organization",
+		Label: "Source Organization",
 	}
 	f.Fields["state"] = &Field{
-		Name:        "state",
-		Label:       "State",
-		Placeholder: "State",
-		Options:     ObjectStateList,
+		Name:    "state",
+		Label:   "State",
+		Options: ObjectStateList,
 	}
 	f.Fields["storage_option"] = &Field{
-		Name:        "storage_option",
-		Label:       "Storage Option",
-		Placeholder: "Storage Option",
-		Options:     StorageOptionList,
+		Name:    "storage_option",
+		Label:   "Storage Option",
+		Options: StorageOptionList,
 	}
 	f.Fields["updated_at__lteq"] = &Field{
-		Name:        "updated_at__lteq",
-		Label:       "Updated On or Before",
-		Placeholder: "Updated On or Before",
+		Name:  "updated_at__lteq",
+		Label: "Updated On or Before",
 	}
 	f.Fields["updated_at__gteq"] = &Field{
-		Name:        "updated_at__gteq",
-		Label:       "Updated On or After",
-		Placeholder: "Updated On or After",
+		Name:  "updated_at__gteq",
+		Label: "Updated On or After",
 	}
 }
 

--- a/forms/password_reset_form.go
+++ b/forms/password_reset_form.go
@@ -19,26 +19,23 @@ func NewPasswordResetForm(userToEdit *pgmodels.User) *PasswordResetForm {
 
 func (f *PasswordResetForm) init() {
 	f.Fields["OldPassword"] = &Field{
-		Name:        "OldPassword",
-		ErrMsg:      pgmodels.ErrUserPwdIncorrect,
-		Label:       "Current Password",
-		Placeholder: "Current Password",
+		Name:   "OldPassword",
+		ErrMsg: pgmodels.ErrUserPwdIncorrect,
+		Label:  "Current Password",
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["NewPassword"] = &Field{
-		Name:        "NewPassword",
-		Label:       "New Password",
-		Placeholder: "New Password",
+		Name:  "NewPassword",
+		Label: "New Password",
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["ConfirmNewPassword"] = &Field{
-		Name:        "ConfirmNewPassword",
-		Label:       "Confirm New Password",
-		Placeholder: "Confirm New Password",
+		Name:  "ConfirmNewPassword",
+		Label: "Confirm New Password",
 		Attrs: map[string]string{
 			"required": "",
 		},

--- a/forms/premis_event_filter_form.go
+++ b/forms/premis_event_filter_form.go
@@ -35,46 +35,38 @@ func NewPremisEventFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmodel
 
 func (f *PremisEventFilterForm) init() {
 	f.Fields["date_time__gteq"] = &Field{
-		Name:        "date_time__gteq",
-		Label:       "Date on or After",
-		Placeholder: "Date on or After",
+		Name:  "date_time__gteq",
+		Label: "Date on or After",
 	}
 	f.Fields["date_time__lteq"] = &Field{
-		Name:        "date_time__lteq",
-		Label:       "Date on or Before",
-		Placeholder: "Date on or Before",
+		Name:  "date_time__lteq",
+		Label: "Date on or Before",
 	}
 	f.Fields["event_type"] = &Field{
-		Name:        "event_type",
-		Label:       "Event Type",
-		Placeholder: "Event Type",
-		Options:     Options(constants.EventTypes),
+		Name:    "event_type",
+		Label:   "Event Type",
+		Options: Options(constants.EventTypes),
 	}
 	f.Fields["generic_file_identifier"] = &Field{
-		Name:        "generic_file_identifier",
-		Label:       "File Identifier",
-		Placeholder: "File Identifier",
+		Name:  "generic_file_identifier",
+		Label: "File Identifier",
 	}
 	f.Fields["identifier"] = &Field{
-		Name:        "identifier",
-		Label:       "Identifier (UUID)",
-		Placeholder: "Identifier (UUID)",
+		Name:  "identifier",
+		Label: "Identifier (UUID)",
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["intellectual_object_identifier"] = &Field{
-		Name:        "intellectual_object_identifier",
-		Label:       "Object Identifier",
-		Placeholder: "Object Identifier",
+		Name:  "intellectual_object_identifier",
+		Label: "Object Identifier",
 	}
 	f.Fields["outcome"] = &Field{
-		Name:        "outcome",
-		Label:       "Outcome",
-		Placeholder: "Outcome",
+		Name:  "outcome",
+		Label: "Outcome",
 		// Fix options: https://trello.com/c/VooirpKZ
 		//Options:     Options(constants.EventOutcomes),
 		Options: Options([]string{"Success", "Failed"}),

--- a/forms/two_factor_setup_form.go
+++ b/forms/two_factor_setup_form.go
@@ -29,10 +29,9 @@ func (f *TwoFactorSetupForm) init() {
 		},
 	}
 	f.Fields["PhoneNumber"] = &Field{
-		Name:        "PhoneNumber",
-		Label:       "PhoneNumber",
-		Placeholder: "PhoneNumber",
-		ErrMsg:      pgmodels.ErrUserPhone,
+		Name:   "PhoneNumber",
+		Label:  "PhoneNumber",
+		ErrMsg: pgmodels.ErrUserPhone,
 		Attrs: map[string]string{
 			"required": "",
 		},

--- a/forms/user_filter_form.go
+++ b/forms/user_filter_form.go
@@ -34,31 +34,26 @@ func NewUserFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmodels.User)
 
 func (f *UserFilterForm) init() {
 	f.Fields["email__contains"] = &Field{
-		Name:        "email__contains",
-		Label:       "Email Contains",
-		Placeholder: "Email Contains",
+		Name:  "email__contains",
+		Label: "Email Contains",
 	}
 	f.Fields["name__contains"] = &Field{
-		Name:        "name__contains",
-		Label:       "Name Contains",
-		Placeholder: "Name Contains",
+		Name:  "name__contains",
+		Label: "Name Contains",
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["role"] = &Field{
-		Name:        "role",
-		Label:       "Role",
-		Placeholder: "Role",
-		Options:     AllRolesList,
+		Name:    "role",
+		Label:   "Role",
+		Options: AllRolesList,
 	}
 	f.Fields["deactivated_at__is_null"] = &Field{
-		Name:        "deactivated_at__is_null",
-		Label:       "Status",
-		Placeholder: "Status",
+		Name:  "deactivated_at__is_null",
+		Label: "Status",
 		Options: []*ListOption{
 			{"true", "Active", false},
 			{"false", "Inactive", false},

--- a/forms/user_form.go
+++ b/forms/user_form.go
@@ -39,29 +39,26 @@ func NewUserForm(userToEdit *pgmodels.User, actingUser *pgmodels.User) (*UserFor
 
 func (f *UserForm) init() {
 	f.Fields["Name"] = &Field{
-		Name:        "Name",
-		ErrMsg:      pgmodels.ErrUserName,
-		Label:       "Name",
-		Placeholder: "Name",
+		Name:   "Name",
+		ErrMsg: pgmodels.ErrUserName,
+		Label:  "Name",
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["Email"] = &Field{
-		Name:        "Email",
-		ErrMsg:      pgmodels.ErrUserEmail,
-		Label:       "Email Address",
-		Placeholder: "Email Address",
+		Name:   "Email",
+		ErrMsg: pgmodels.ErrUserEmail,
+		Label:  "Email Address",
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["PhoneNumber"] = &Field{
-		Name:        "PhoneNumber",
-		ErrMsg:      pgmodels.ErrUserPhone,
-		Label:       "Phone",
-		Placeholder: "Phone in format 212-555-1212",
-		Attrs:       map[string]string{
+		Name:   "PhoneNumber",
+		ErrMsg: pgmodels.ErrUserPhone,
+		Label:  "Phone in format 212-555-1212",
+		Attrs:  map[string]string{
 			//"pattern": "[0-9]{10,11}",
 		},
 	}
@@ -75,10 +72,9 @@ func (f *UserForm) init() {
 		},
 	}
 	f.Fields["GracePeriod"] = &Field{
-		Name:        "GracePeriod",
-		Label:       "Must enable two-factor auth by",
-		Placeholder: "mm/dd/yyyy",
-		ErrMsg:      pgmodels.ErrUserGracePeriod,
+		Name:   "GracePeriod",
+		Label:  "Must enable two-factor auth by (mm/dd/yyyy)",
+		ErrMsg: pgmodels.ErrUserGracePeriod,
 		Attrs: map[string]string{
 			"min": "2021-01-01",
 			"max": "2099-12-31",

--- a/forms/work_item_filter_form.go
+++ b/forms/work_item_filter_form.go
@@ -35,98 +35,81 @@ func NewWorkItemFilterForm(fc *pgmodels.FilterCollection, actingUser *pgmodels.U
 
 func (f *WorkItemFilterForm) init() {
 	f.Fields["action__in"] = &Field{
-		Name:        "action__in",
-		Label:       "Action",
-		Placeholder: "Action",
-		Options:     Options(constants.WorkItemActions),
+		Name:    "action__in",
+		Label:   "Action",
+		Options: Options(constants.WorkItemActions),
 		Attrs: map[string]string{
 			"multiple": "multiple",
 		},
 	}
 	f.Fields["alt_identifier"] = &Field{
-		Name:        "alt_identifier",
-		Label:       "Alternate Identifier",
-		Placeholder: "Alternate Identifier",
+		Name:  "alt_identifier",
+		Label: "Alternate Identifier",
 	}
 	f.Fields["bag_date__gteq"] = &Field{
-		Name:        "bag_date__gteq",
-		Label:       "Bag Date On or After",
-		Placeholder: "Bag Date On or After",
+		Name:  "bag_date__gteq",
+		Label: "Bag Date On or After",
 	}
 	f.Fields["bag_date__lteq"] = &Field{
-		Name:        "bag_date__lteq",
-		Label:       "Bag Date On or Before",
-		Placeholder: "Bag Date On or Before",
+		Name:  "bag_date__lteq",
+		Label: "Bag Date On or Before",
 	}
 	f.Fields["bag_group_identifier"] = &Field{
-		Name:        "bag_group_identifier",
-		Label:       "Bag Group Identifier",
-		Placeholder: "Bag Group Identifier",
+		Name:  "bag_group_identifier",
+		Label: "Bag Group Identifier",
 	}
 	f.Fields["bagit_profile_identifier"] = &Field{
-		Name:        "bagit_profile_identifier",
-		Label:       "BagIt Profile",
-		Placeholder: "BagIt Profile",
-		Options:     BagItProfileIdentifiers,
+		Name:    "bagit_profile_identifier",
+		Label:   "BagIt Profile",
+		Options: BagItProfileIdentifiers,
 	}
 	f.Fields["bucket"] = &Field{
-		Name:        "bucket",
-		Label:       "Bucket",
-		Placeholder: "Bucket",
+		Name:  "bucket",
+		Label: "Bucket",
 	}
 	f.Fields["date_processed__gteq"] = &Field{
-		Name:        "date_processed__gteq",
-		Label:       "Processed On or After",
-		Placeholder: "Processed On or After",
+		Name:  "date_processed__gteq",
+		Label: "Processed On or After",
 	}
 	f.Fields["date_processed__lteq"] = &Field{
-		Name:        "date_processed__lteq",
-		Label:       "Processed On or Before",
-		Placeholder: "Processed On or Before",
+		Name:  "date_processed__lteq",
+		Label: "Processed On or Before",
 	}
 	f.Fields["etag"] = &Field{
-		Name:        "etag",
-		Label:       "ETag (from S3 upload)",
-		Placeholder: "ETag",
+		Name:  "etag",
+		Label: "ETag (from S3 upload)",
 	}
 	f.Fields["generic_file_identifier"] = &Field{
-		Name:        "generic_file_identifier",
-		Label:       "File Identifier",
-		Placeholder: "File Identifier",
+		Name:  "generic_file_identifier",
+		Label: "File Identifier",
 	}
 	f.Fields["institution_id"] = &Field{
-		Name:        "institution_id",
-		Label:       "Institution",
-		Placeholder: "Institution",
-		Options:     f.instOptions,
+		Name:    "institution_id",
+		Label:   "Institution",
+		Options: f.instOptions,
 	}
 	f.Fields["name"] = &Field{
-		Name:        "name",
-		Label:       "Name of tar file",
-		Placeholder: "Name of tar file",
+		Name:  "name",
+		Label: "Name of tar file",
 	}
 	f.Fields["needs_admin_review"] = &Field{
-		Name:        "needs_admin_review",
-		Label:       "Needs Admin Review",
-		Placeholder: "Needs Admin Review",
-		Options:     YesNoList,
+		Name:    "needs_admin_review",
+		Label:   "Needs Admin Review",
+		Options: YesNoList,
 	}
 	f.Fields["node__not_null"] = &Field{
-		Name:        "node__not_null",
-		Label:       "Has Worker",
-		Placeholder: "Has Worker",
-		Options:     YesNoList,
+		Name:    "node__not_null",
+		Label:   "Has Worker",
+		Options: YesNoList,
 	}
 	f.Fields["object_identifier"] = &Field{
-		Name:        "object_identifier",
-		Label:       "Object Identifier",
-		Placeholder: "Object Identifier",
+		Name:  "object_identifier",
+		Label: "Object Identifier",
 	}
 	// Special field for admin reporting.
 	f.Fields["report"] = &Field{
-		Name:        "report",
-		Label:       "Quick Reports",
-		Placeholder: "Quick Reports",
+		Name:  "report",
+		Label: "Quick Reports",
 		Options: []*ListOption{
 			{"in_process", "In Process - Last 30 Days", false},
 			{"cancelled_failed", "Canceled/Failed/Suspended - Last 30 Days", false},
@@ -135,51 +118,44 @@ func (f *WorkItemFilterForm) init() {
 		},
 	}
 	f.Fields["size__gteq"] = &Field{
-		Name:        "size__gteq",
-		Label:       "Min Size",
-		Placeholder: "Min Size",
+		Name:  "size__gteq",
+		Label: "Min Size",
 	}
 	f.Fields["size__lteq"] = &Field{
-		Name:        "size__lteq",
-		Label:       "Max Size",
-		Placeholder: "Max Size",
+		Name:  "size__lteq",
+		Label: "Max Size",
 	}
 	f.Fields["stage__in"] = &Field{
-		Name:        "stage__in",
-		Label:       "Work Item Stage",
-		Placeholder: "Work Item Stage",
-		Options:     Options(constants.Stages),
+		Name:    "stage__in",
+		Label:   "Work Item Stage",
+		Options: Options(constants.Stages),
 		Attrs: map[string]string{
 			"multiple": "multiple",
 		},
 	}
 	f.Fields["status__in"] = &Field{
-		Name:        "status__in",
-		Label:       "Status",
-		Placeholder: "Status",
-		Options:     Options(constants.Statuses),
+		Name:    "status__in",
+		Label:   "Status",
+		Options: Options(constants.Statuses),
 		Attrs: map[string]string{
 			"multiple": "multiple",
 		},
 	}
 	f.Fields["storage_option"] = &Field{
-		Name:        "storage_option",
-		Label:       "Storage Option",
-		Placeholder: "Storage Option",
-		Options:     StorageOptionList,
+		Name:    "storage_option",
+		Label:   "Storage Option",
+		Options: StorageOptionList,
 	}
 	f.Fields["user"] = &Field{
-		Name:        "user",
-		Label:       "Initiated By",
-		Placeholder: "User email address",
+		Name:  "user",
+		Label: "Initiated By (User email address)",
 	}
 	// This is a special case. Doesn't quite
 	// fit with our framework.
 	f.Fields["redis_only"] = &Field{
-		Name:        "redis_only",
-		Label:       "Redis Only",
-		Placeholder: "Redis Only",
-		Options:     YesNoList,
+		Name:    "redis_only",
+		Label:   "Redis Only",
+		Options: YesNoList,
 	}
 }
 

--- a/forms/work_item_form.go
+++ b/forms/work_item_form.go
@@ -23,72 +23,64 @@ func NewWorkItemForm(workItem *pgmodels.WorkItem) *WorkItemForm {
 
 func (f *WorkItemForm) init() {
 	f.Fields["Stage"] = &Field{
-		Name:        "Stage",
-		Label:       "Stage",
-		Placeholder: "Stage",
-		ErrMsg:      pgmodels.ErrItemStage,
-		Options:     Options(constants.Stages),
+		Name:    "Stage",
+		Label:   "Stage",
+		ErrMsg:  pgmodels.ErrItemStage,
+		Options: Options(constants.Stages),
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["Status"] = &Field{
-		Name:        "Status",
-		Label:       "Status",
-		Placeholder: "Status",
-		ErrMsg:      pgmodels.ErrItemStatus,
-		Options:     Options(constants.Statuses),
+		Name:    "Status",
+		Label:   "Status",
+		ErrMsg:  pgmodels.ErrItemStatus,
+		Options: Options(constants.Statuses),
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["Retry"] = &Field{
-		Name:        "Retry",
-		Label:       "Retry",
-		Placeholder: "Retry",
-		ErrMsg:      "Please choose yes or no.",
-		Options:     YesNoList,
+		Name:    "Retry",
+		Label:   "Retry",
+		ErrMsg:  "Please choose yes or no.",
+		Options: YesNoList,
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["NeedsAdminReview"] = &Field{
-		Name:        "NeedsAdminReview",
-		Label:       "NeedsAdminReview",
-		Placeholder: "NeedsAdminReview",
-		ErrMsg:      "Please choose yes or no.",
-		Options:     YesNoList,
+		Name:    "NeedsAdminReview",
+		Label:   "NeedsAdminReview",
+		ErrMsg:  "Please choose yes or no.",
+		Options: YesNoList,
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["Note"] = &Field{
-		Name:        "Note",
-		Label:       "Note",
-		Placeholder: "Note",
-		ErrMsg:      pgmodels.ErrItemNote,
+		Name:   "Note",
+		Label:  "Note",
+		ErrMsg: pgmodels.ErrItemNote,
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["Node"] = &Field{
-		Name:        "Node",
-		Label:       "Node",
-		Placeholder: "Node",
-		Attrs:       map[string]string{},
+		Name:  "Node",
+		Label: "Node",
+		Attrs: map[string]string{},
 	}
 	f.Fields["PID"] = &Field{
-		Name:        "PID",
-		Label:       "PID",
-		Placeholder: "PID",
+		Name:  "PID",
+		Label: "PID",
 		Attrs: map[string]string{
 			"required": "",
 		},
 	}
 	f.Fields["IntellectualObjectID"] = &Field{
-		Name:        "IntellectualObjectID",
-		Label:       "Intellectual Object",
-		Placeholder: "Intellectual Object",
+		Name:  "IntellectualObjectID",
+		Label: "Intellectual Object",
 	}
 }
 

--- a/static/js/modules/charts.js
+++ b/static/js/modules/charts.js
@@ -6,7 +6,7 @@
 // fillColors are used in bar charts, pie charts, etc. rendered
 // by chart.js on the front end. Used by helpers/templates.go.
 const fillColors = [
-	"rgba(187, 149, 102, 1)",
+	"rgba(125, 107, 25, 1)",
 	"rgba(19, 19, 92, 1)",
 	"rgba(51, 48, 48, 1)",
 	"rgba(96, 130, 146, 1)",
@@ -17,7 +17,7 @@ const fillColors = [
 // barBorders are used in bar charts, pie charts, etc. rendered
 // by chart.js on the front end. Used by helpers/templates.go.
 const barBorders = [
-	"rgba(187, 149, 102, 1)",
+	"rgba(125, 107, 25, 1)",
 	"rgba(19, 19, 92, 1)",
 	"rgba(51, 48, 48, 1)",
 	"rgba(96, 130, 146, 1)",

--- a/static/js/modules/charts.js
+++ b/static/js/modules/charts.js
@@ -9,9 +9,9 @@ const fillColors = [
 	"rgba(125, 107, 25, 1)",
 	"rgba(19, 19, 92, 1)",
 	"rgba(51, 48, 48, 1)",
-	"rgba(96, 130, 146, 1)",
+	"rgba(84, 114, 128, 1)",
 	"rgba(147, 90, 21, 1)",
-	"rgba(96, 151, 205, 1)",
+	"rgba(77, 122, 166, 1)",
 ]
 
 // barBorders are used in bar charts, pie charts, etc. rendered
@@ -20,9 +20,9 @@ const barBorders = [
 	"rgba(125, 107, 25, 1)",
 	"rgba(19, 19, 92, 1)",
 	"rgba(51, 48, 48, 1)",
-	"rgba(96, 130, 146, 1)",
+	"rgba(84, 114, 128, 1)",
 	"rgba(147, 90, 21, 1)",
-	"rgba(96, 151, 205, 1)",
+	"rgba(77, 122, 166, 1)",
 ]
 
 // fillColor returns a color for a bar, pie slice, etc. in a

--- a/static/scss/shared/_global.scss
+++ b/static/scss/shared/_global.scss
@@ -107,10 +107,11 @@ pre.with-wrap {
   white-space: nowrap;
 }
 
-/* TODO: This is not too pretty, but serviceable for now. */
+/* The flash cookie shows messages in the banner. */
 .flash {
   padding: 8px;
-  background-color: $blue-light;
+  background-color: $purple;
+  color: $white;
   margin-bottom: 1rem;
   border-radius: 4px;
 }

--- a/views/dashboard/_alerts.html
+++ b/views/dashboard/_alerts.html
@@ -7,7 +7,7 @@
       Recent Notifications
     </h1>
     <a class="is-flex is-align-items-center is-grey-dark is-not-underlined" href="/alerts">
-      see all
+      See All Recent Notifications
       <span class="material-icons md-16 ml-2" aria-hidden="true">arrow_forward</span>
     </a>
   </div>
@@ -35,5 +35,14 @@
     </tbody>
   </table>
 </div>
+
+<script>
+  /* If an alert has focus, you can open details by pressing the Enter key. */
+  function handleKeyPressWhileAlertFocused(event, recentAlert) {
+    if (event.key == "Enter") {
+      recentAlert.click()
+    }
+  }
+</script>
 
 {{ end }}

--- a/views/dashboard/_alerts.html
+++ b/views/dashboard/_alerts.html
@@ -15,7 +15,7 @@
   <table class="table is-hoverable is-fullwidth has-padding is-borderless">
     <tbody>
       {{ range $index, $alert := .alerts }}
-      <tr class="clickable" data-modal="modal-one" data-xhr-url="/alerts/show/{{ $alert.ID }}/{{ $alert.UserID }}?modal=true">
+      <tr class="clickable" tabindex="0" data-modal="modal-one" data-xhr-url="/alerts/show/{{ $alert.ID }}/{{ $alert.UserID }}?modal=true" onkeydown="handleKeyPressWhileAlertFocused(event, this)">
         <td class="pl-5">
           <div class="is-flex is-align-items-center">
             <span class="action-icon mr-3"><!-- TODO Make this update with correct icon, the icon is for the notification type, not read status  -->

--- a/views/dashboard/_work_items.html
+++ b/views/dashboard/_work_items.html
@@ -4,7 +4,7 @@
   <div class="box-header is-flex is-justify-content-space-between is-align-items-center">
     <h1 class="h2">Recent Work Items</h1>
     <a class="is-flex is-align-items-center is-grey-dark is-not-underlined" href="/work_items">
-      see all
+      See All Recent Work Items
       <span class="material-icons md-16 ml-2" aria-hidden="true">arrow_forward</span>
     </a>
   </div>
@@ -12,7 +12,7 @@
   <table class="table is-hoverable is-fullwidth has-padding is-borderless">
     <tbody>
       {{ range $index, $item := .items }}
-      <tr class="clickable" onclick="document.location.href='/work_items/show/{{ $item.ID }}'">
+      <tr class="clickable" tabindex="0" onclick="document.location.href='/work_items/show/{{ $item.ID }}'" onkeydown="handleKeyPressWhileWorkItemFocused(event, this)">
         <td class="pl-5">
           <div class="is-flex is-align-items-center wrap-long-words">
             <span class="action-icon mr-3">
@@ -29,5 +29,14 @@
     </tbody>
   </table>
 </div>
+
+<script>
+  /* If a work item has focus, you can open details by pressing the Enter key. */
+  function handleKeyPressWhileWorkItemFocused(event, workItem) {
+    if (event.key == "Enter") {
+      workItem.click()
+    }
+  }
+</script>
 
 {{ end }}

--- a/views/objects/_file_list.html
+++ b/views/objects/_file_list.html
@@ -47,7 +47,7 @@
     </thead>
     {{ range $index, $file := .files }}
     <tr>
-      <td class="clickable" data-toggle-table-row="file-{{ $file.ID }}">[+]</td>
+      <td class="clickable" tabindex="0" data-toggle-table-row="file-{{ $file.ID }}" onkeydown="handleKeyPressWhileFileExpandFocused(event, this)">Expand [+]</td>
       <td class="is-grey-dark">{{ truncateStart $file.Identifier 60 }}</td>
       <td class="is-grey-dark">{{ $file.FileFormat }}</td>
       <td class="is-grey-dark num text-sm has-text-right">{{ humanSize $file.Size }}</td>
@@ -117,6 +117,13 @@
 
 </div>
 
-
+<script>
+  /* If a file has focus, you can expand details by pressing the Enter key. */
+  function handleKeyPressWhileFileExpandFocused(event, file) {
+    if (event.key == "Enter") {
+      file.click()
+    }
+  }
+</script>
 
 {{ end }}

--- a/views/objects/_file_list.html
+++ b/views/objects/_file_list.html
@@ -25,8 +25,10 @@
       <div class="field is-grouped column is-half">
         <label class="label is-sr-only" for="fileFilter">Basic Text Input</label>
         <div class="control is-expanded">
-          <input class="input" type="text" placeholder="Filter by partial identifier or exact checksum" id="fileFilter"
-            value="{{ .fileFilter }}">
+          <label>
+            Filter by partial identifier or exact checksum:
+            <input class="input" type="text" id="fileFilter" value="{{ .fileFilter }}">
+          </label>
         </div>
         <div class="control">
           <input class="button is-primary" type="button" value="Filter" onclick="filterFiles('{{ .state }}')" />

--- a/views/shared/_side_nav.html
+++ b/views/shared/_side_nav.html
@@ -20,7 +20,7 @@
     <li><a href="/work_items"><span class="material-icons" aria-hidden="true">build</span> Work Items</a></li>
     {{ end }}
 
-    <li role="presentation"><hr /></li>
+    <li><hr role="presentation" /></li>
   
     {{ if userCan .CurrentUser "DepositReportShow" .CurrentUser.InstitutionID }}
     <li><a href="/reports/deposits?storage_option=Total"><span class="material-icons" aria-hidden="true">insert_chart</span> Reports</a></li>
@@ -77,7 +77,7 @@
       </ul>
     </li>
 
-    <li role="presentation"><hr /></li>
+    <li><hr role="presentation" /></li>
   
     <li><a href="/users/sign_out"><span class="material-icons" aria-hidden="true">logout</span> Sign Out</a></li>
   </ul>

--- a/views/shared/_side_nav.html
+++ b/views/shared/_side_nav.html
@@ -20,7 +20,7 @@
     <li><a href="/work_items"><span class="material-icons" aria-hidden="true">build</span> Work Items</a></li>
     {{ end }}
 
-    <li><hr /></li>
+    <li role="presentation"><hr /></li>
   
     {{ if userCan .CurrentUser "DepositReportShow" .CurrentUser.InstitutionID }}
     <li><a href="/reports/deposits?storage_option=Total"><span class="material-icons" aria-hidden="true">insert_chart</span> Reports</a></li>
@@ -77,7 +77,7 @@
       </ul>
     </li>
 
-    <li><hr /></li>
+    <li role="presentation"><hr /></li>
   
     <li><a href="/users/sign_out"><span class="material-icons" aria-hidden="true">logout</span> Sign Out</a></li>
   </ul>

--- a/views/users/enter_password_reset_token.html
+++ b/views/users/enter_password_reset_token.html
@@ -21,7 +21,10 @@
       <div class="field">
         <label class="label" for="tokenInput">Password reset token</label>
         <div class="control">
-          <input class="input" type="text" id="tokenInput" name="token" placeholder="Password reset token" autofocus>
+          <label>
+            Password reset token:
+            <input class="input" type="text" id="tokenInput" name="token" autofocus>
+          </label>
         </div>
       </div>
       {{ template "forms/csrf_token.html" . }}

--- a/views/users/form.html
+++ b/views/users/form.html
@@ -15,6 +15,8 @@
     </div>
     {{ end }}
 
+    <h1>Add New User</h1>
+
     <div class="columns">
       <div class="column">{{ template "forms/text_input.html" .form.Fields.Name }}</div>
     </div>

--- a/views/users/form.html
+++ b/views/users/form.html
@@ -15,7 +15,11 @@
     </div>
     {{ end }}
 
+    {{ if .isEdit }}
+    <h1>Edit User</h1>
+    {{ else }}
     <h1>Add New User</h1>
+    {{ end }}
 
     <div class="columns">
       <div class="column">{{ template "forms/text_input.html" .form.Fields.Name }}</div>

--- a/views/users/reset_password.html
+++ b/views/users/reset_password.html
@@ -25,7 +25,7 @@
     </div>
     {{ end }}
 
-    <div>New password must contain at least 8 characters. Password must contain at least one uppercase letter, one lowercase letter and one number.</div>
+    <div id="newPwdInstructions">New password must contain at least 8 characters. Password must contain at least one uppercase letter, one lowercase letter and one number.</div>
 
     <div class="columns">
       <div class="column">{{ template "forms/password.html" .form.Fields.NewPassword }}</div>

--- a/views/users/reset_password.html
+++ b/views/users/reset_password.html
@@ -25,6 +25,8 @@
     </div>
     {{ end }}
 
+    <div>New password must contain at least 8 characters. Password must contain at least one uppercase letter, one lowercase letter and one number.</div>
+
     <div class="columns">
       <div class="column">{{ template "forms/password.html" .form.Fields.NewPassword }}</div>
       <div class="column">{{ template "forms/password.html" .form.Fields.ConfirmNewPassword }}</div>

--- a/views/users/sign_in.html
+++ b/views/users/sign_in.html
@@ -77,10 +77,19 @@
         <option value="admin@test.edu">admin@test.edu (Test.edu Admin)</option>
         <option value="user@test.edu">user@test.edu (Test.edu User)</option>
       </select>
-      <input type="password" name="password" placeholder="Password" value="password">
+      <label>
+        Password:
+        <input type="password" name="password" value="password">
+      </label>
       {{ else }}
-      <input type="text" name="email" id="emailInput" placeholder="Email address" autofocus>
-      <input type="password" name="password" placeholder="Password">
+      <label>
+        Email address:
+        <input type="text" name="email" id="emailInput" autofocus>
+      </label>
+      <label>
+        Password:
+        <input type="password" name="password" value="password">
+      </label>
       {{ end }}
       <div class="sign-in-submit">
         <input type="submit" value="Sign In">

--- a/web/webui/intellectual_objects_controller_test.go
+++ b/web/webui/intellectual_objects_controller_test.go
@@ -150,7 +150,7 @@ func TestObjectByIdentifier(t *testing.T) {
 	resp = testutil.Inst1UserClient.GET("/objects").WithQuery("identifier__starts_with", "institution1.edu/does-not-exist").Expect()
 	assert.Equal(t, http.StatusOK, resp.Raw().StatusCode)
 
-	expected := `<input class="input" type="text" id="identifier__starts_with" name="identifier__starts_with" value="institution1.edu/does-not-exist" placeholder="Object Identifier (Prefix or Exact)"`
+	expected := `<input class="input" type="text" id="identifier__starts_with" name="identifier__starts_with" value="institution1.edu/does-not-exist"`
 	html = resp.Body().Raw()
 	assert.Contains(t, html, expected)
 }

--- a/web/webui/users_controller.go
+++ b/web/webui/users_controller.go
@@ -77,6 +77,7 @@ func UserNew(c *gin.Context) {
 		return
 	}
 	req.TemplateData["form"] = form
+	req.TemplateData["isEdit"] = false
 	c.HTML(http.StatusOK, form.Template, req.TemplateData)
 }
 
@@ -111,6 +112,7 @@ func UserEdit(c *gin.Context) {
 		return
 	}
 	req.TemplateData["form"] = form
+	req.TemplateData["isEdit"] = true
 	c.HTML(http.StatusOK, form.Template, req.TemplateData)
 }
 


### PR DESCRIPTION
This PR contains several accessibility improvements to the Registry interface.

Included:
87526 - Screen reader now announces correct number of items in the sidebar.
87584 - Add New User page now has a header
87493 - Work Items and Notifications now navigable via Tab key and each individual can be opened with Enter
87551 - Files list on Object page is now navigable via Tab key and each individual can be expanded with Enter
87559 - Error callouts now appear with white text on a purple background with sufficient contrast.
87642 - Redundant placeholder text has been removed from fields where it was too faint to be seen anyway
87495 - Dashboard links for "see all" have been updated to say See All Recent Work Items and See All Recent Notifications
87906 - Graph colors now have sufficient contrast against background