### PR TITLE
Load CSV fixtures from temp files

### DIFF
--- a/db/testutil.go
+++ b/db/testutil.go
@@ -229,23 +229,21 @@ func loadCSVFiles(db *pg.DB) error {
 // The CSV files were created with the Postgres COPY command.
 func loadCSVFile(db *pg.DB, table string) error {
 	panicOnWrongEnv()
-	ctx := common.Context()
 	file := filepath.Join(common.ProjectRoot(), "db", "fixtures", table+".csv")
 
-	// On Travis, posgres user can't read from Travis' home dir,
-	// so we have to copy our csv file to a readable temp dir.
-	if ctx.Config.EnvName == "travis" {
-		tmpFile := path.Join(os.TempDir(), table+".csv")
-		err := common.CopyFile(file, tmpFile, 0666)
-		if err != nil {
-			return err
-		}
-		defer os.Remove(tmpFile)
-		file = tmpFile
+	// Copy files to temp directory so we don't have to worry about
+	// permissions on the original files. This prevents us having to set
+	// world executable permissions on our entire home directory on Linux.
+	tmpFile := path.Join(os.TempDir(), table+".csv")
+	err := common.CopyFile(file, tmpFile, 0666)
+	if err != nil {
+		return err
 	}
+	defer os.Remove(tmpFile)
+	file = tmpFile
 
 	sql := fmt.Sprintf(`copy "%s" from '%s' csv header`, table, file)
-	err := runTransaction(db, sql)
+	err = runTransaction(db, sql)
 	if err != nil {
 		err = fmt.Errorf(`Error executing "%s": %v`, sql, err)
 	}


### PR DESCRIPTION
Load CSV fixtures from temp files when running tests so we don't have to set world executable privileges on our entire home directory. On Linux, the postgres COPY command that loads test fixtures works only if 1) the postgres user (and hence, world) has executable privileges to delve into the user's home directory to find the CSV fixture files, or 2) the CSV files are copied to a readable temp directory. 

This change copies the CSV to readable temp files by default. This code has been in place for years, but was only invoked when APT_ENV=travis. In this change, we copy to db fixtures (CSV files) to a temp directory even if APT_ENV is "dev" or "test".

Just make sure `./registry test` passes on your machine.